### PR TITLE
care IllegalArgumentException

### DIFF
--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/MastodonClient.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/MastodonClient.kt
@@ -102,6 +102,8 @@ private constructor(
                             .post(body)
                             .build())
             return call.execute()
+        } catch (e: IllegalArgumentException) {
+            throw Mastodon4jRequestException(e)
         } catch (e: IOException) {
             throw Mastodon4jRequestException(e)
         }


### PR DESCRIPTION
care IllegalArgumentException (e.g. invalid url like "https://mstdn..jp/api/v1/apps")

またまたJavaレイヤーの話で恐縮ですが、不正なURLで apps.createApp すると RuntimeException で落ちるのを防ぎたいです。

- Crashlytics 的にはこんな感じです http://crashes.to/s/47daee1d9c4
- Kotlinにmulti-catchがないっぽいのでベタな実装になるのが気持ち悪いです
- get/patch/delete メソッドでの必要性が分からなかったので postUrl だけ追加しています
