### PR TITLE
Support custom emoji at mastodon 2.0

### DIFF
--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Emoji.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Emoji.kt
@@ -1,0 +1,17 @@
+package com.sys1yagi.mastodon4j.api.entity
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#emoji
+ */
+class Emoji(
+        @SerializedName("shortcode")
+        val shortcode: String = "",
+
+        @SerializedName("static_url")
+        val staticUrl: String = "",
+
+        @SerializedName("url")
+        val url: String = "") {
+}

--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Status.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Status.kt
@@ -15,6 +15,7 @@ class Status(
         @SerializedName("reblog") val reblog: Status? = null,
         @SerializedName("content") val content: String = "",
         @SerializedName("created_at") val createdAt: String = "",
+        @SerializedName("emojis") val emojis: List<Emoji> = emptyList(),
         @SerializedName("reblogs_count") val reblogsCount: Int = 0,
         @SerializedName("favourites_count") val favouritesCount: Int = 0,
         @SerializedName("reblogged") val isReblogged: Boolean = false,


### PR DESCRIPTION
Mastodon2.0のAPIが返すStatusに、カスタム絵文字が含まれるようになったので、Emojiクラスと、Status#emojisを追加して、mastodon4jで絵文字を扱えるようにしました