### PR TITLE
Streaming bug fix.(data missing , I/O exception occurred when shutdown.)

### DIFF
--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/Dispatcher.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/Dispatcher.kt
@@ -14,7 +14,7 @@ class Dispatcher {
     })
 
     val lock = ReentrantLock()
-    val shutdownTime = 5000L
+    val shutdownTime = 1000L
 
     fun invokeLater(task: Runnable) = executorService.execute(task)
 

--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/method/Streaming.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/method/Streaming.kt
@@ -20,22 +20,35 @@ class Streaming(private val client: MastodonClient) {
             val dispatcher = Dispatcher()
             dispatcher.invokeLater(Runnable {
                 while (true) {
-                    val line = reader.readLine()
-                    if (line == null || line.isEmpty()) {
-                        continue
-                    }
-                    val payload = reader.readLine()
-                    val event = line.split(":")[1].trim()
-                    if (event == "update") {
-                        val start = payload.indexOf(":") + 1
-                        val json = payload.substring(start).trim()
-                        val status = client.getSerializer().fromJson(
-                                json,
-                                Status::class.java
-                        )
-                        handler.onStatus(status)
+                    try{
+                        val line = reader.readLine()
+                        if (line == null || line.isEmpty()) {
+                            continue
+                        }
+                        val type = line.split(":")[0].trim()
+                        if(type != "event"){
+                            continue
+                        }
+                        val event = line.split(":")[1].trim()
+                        val payload = reader.readLine()
+                        val payloadType = payload.split(":")[0].trim()
+                        if(payloadType != "data"){
+                            continue
+                        }
+                        if (event == "update") {
+                            val start = payload.indexOf(":") + 1
+                            val json = payload.substring(start).trim()
+                            val status = client.getSerializer().fromJson(
+                                    json,
+                                    Status::class.java
+                            )
+                            handler.onStatus(status)
+                        }
+                    }catch (e:java.io.InterruptedIOException){
+                        break
                     }
                 }
+                reader.close()
             })
             return Shutdownable(dispatcher)
         } else {
@@ -51,22 +64,35 @@ class Streaming(private val client: MastodonClient) {
             val dispatcher = Dispatcher()
             dispatcher.invokeLater(Runnable {
                 while (true) {
-                    val line = reader.readLine()
-                    if (line == null || line.isEmpty()) {
-                        continue
-                    }
-                    val payload = reader.readLine()
-                    val event = line.split(":")[1].trim()
-                    if (event == "update") {
-                        val start = payload.indexOf(":") + 1
-                        val json = payload.substring(start).trim()
-                        val status = client.getSerializer().fromJson(
-                                json,
-                                Status::class.java
-                        )
-                        handler.onStatus(status)
+                    try{
+                        val line = reader.readLine()
+                        if (line == null || line.isEmpty()) {
+                            continue
+                        }
+                        val type = line.split(":")[0].trim()
+                        if(type != "event"){
+                            continue
+                        }
+                        val event = line.split(":")[1].trim()
+                        val payload = reader.readLine()
+                        val payloadType = payload.split(":")[0].trim()
+                        if(payloadType != "data"){
+                            continue
+                        }
+                        if (event == "update") {
+                            val start = payload.indexOf(":") + 1
+                            val json = payload.substring(start).trim()
+                            val status = client.getSerializer().fromJson(
+                                    json,
+                                    Status::class.java
+                            )
+                            handler.onStatus(status)
+                        }
+                    }catch (e:java.io.InterruptedIOException){
+                        break
                     }
                 }
+                reader.close()
             })
             return Shutdownable(dispatcher)
         } else {
@@ -85,22 +111,35 @@ class Streaming(private val client: MastodonClient) {
             val dispatcher = Dispatcher()
             dispatcher.invokeLater(Runnable {
                 while (true) {
-                    val line = reader.readLine()
-                    if (line == null || line.isEmpty()) {
-                        continue
-                    }
-                    val payload = reader.readLine()
-                    val event = line.split(":")[1].trim()
-                    if (event == "update") {
-                        val start = payload.indexOf(":") + 1
-                        val json = payload.substring(start).trim()
-                        val status = client.getSerializer().fromJson(
-                                json,
-                                Status::class.java
-                        )
-                        handler.onStatus(status)
+                    try{
+                        val line = reader.readLine()
+                        if (line == null || line.isEmpty()) {
+                            continue
+                        }
+                        val type = line.split(":")[0].trim()
+                        if(type != "event"){
+                            continue
+                        }
+                        val event = line.split(":")[1].trim()
+                        val payload = reader.readLine()
+                        val payloadType = payload.split(":")[0].trim()
+                        if(payloadType != "data"){
+                            continue
+                        }
+                        if (event == "update") {
+                            val start = payload.indexOf(":") + 1
+                            val json = payload.substring(start).trim()
+                            val status = client.getSerializer().fromJson(
+                                    json,
+                                    Status::class.java
+                            )
+                            handler.onStatus(status)
+                        }
+                    }catch (e:java.io.InterruptedIOException){
+                        break
                     }
                 }
+                reader.close()
             })
             return Shutdownable(dispatcher)
         } else {
@@ -119,22 +158,35 @@ class Streaming(private val client: MastodonClient) {
             val dispatcher = Dispatcher()
             dispatcher.invokeLater(Runnable {
                 while (true) {
-                    val line = reader.readLine()
-                    if (line == null || line.isEmpty()) {
-                        continue
-                    }
-                    val payload = reader.readLine()
-                    val event = line.split(":")[1].trim()
-                    if (event == "update") {
-                        val start = payload.indexOf(":") + 1
-                        val json = payload.substring(start).trim()
-                        val status = client.getSerializer().fromJson(
-                                json,
-                                Status::class.java
-                        )
-                        handler.onStatus(status)
+                    try{
+                        val line = reader.readLine()
+                        if (line == null || line.isEmpty()) {
+                            continue
+                        }
+                        val type = line.split(":")[0].trim()
+                        if(type != "event"){
+                            continue
+                        }
+                        val event = line.split(":")[1].trim()
+                        val payload = reader.readLine()
+                        val payloadType = payload.split(":")[0].trim()
+                        if(payloadType != "data"){
+                            continue
+                        }
+                        if (event == "update") {
+                            val start = payload.indexOf(":") + 1
+                            val json = payload.substring(start).trim()
+                            val status = client.getSerializer().fromJson(
+                                    json,
+                                    Status::class.java
+                            )
+                            handler.onStatus(status)
+                        }
+                    }catch (e:java.io.InterruptedIOException){
+                        break
                     }
                 }
+                reader.close()
             })
             return Shutdownable(dispatcher)
         } else {
@@ -152,37 +204,50 @@ class Streaming(private val client: MastodonClient) {
             val dispatcher = Dispatcher()
             dispatcher.invokeLater(Runnable {
                 while (true) {
-                    val line = reader.readLine()
-                    if (line == null || line.isEmpty()) {
-                        continue
-                    }
-                    val event = line.split(":")[1].trim()
+                    try{
+                        val line = reader.readLine()
+                        if (line == null || line.isEmpty()) {
+                            continue
+                        }
+                        val type = line.split(":")[0].trim()
+                        if(type != "event"){
+                            continue
+                        }
+                        val event = line.split(":")[1].trim()
+                        val payload = reader.readLine()
+                        val payloadType = payload.split(":")[0].trim()
+                        if(payloadType != "data"){
+                            continue
+                        }
 
-                    val payload = reader.readLine()
-                    val start = payload.indexOf(":") + 1
-                    val json = payload.substring(start).trim()
-                    if (event == "update") {
-                        val status = client.getSerializer().fromJson(
-                                json,
-                                Status::class.java
-                        )
-                        handler.onStatus(status)
-                    }
-                    if (event == "notification") {
-                        val notification = client.getSerializer().fromJson(
-                                json,
-                                Notification::class.java
-                        )
-                        handler.onNotification(notification)
-                    }
-                    if (event == "delete") {
-                        val id = client.getSerializer().fromJson(
-                                json,
-                                Long::class.java
-                        )
-                        handler.onDelete(id)
+                        val start = payload.indexOf(":") + 1
+                        val json = payload.substring(start).trim()
+                        if (event == "update") {
+                            val status = client.getSerializer().fromJson(
+                                    json,
+                                    Status::class.java
+                            )
+                            handler.onStatus(status)
+                        }
+                        if (event == "notification") {
+                            val notification = client.getSerializer().fromJson(
+                                    json,
+                                    Notification::class.java
+                            )
+                            handler.onNotification(notification)
+                        }
+                        if (event == "delete") {
+                            val id = client.getSerializer().fromJson(
+                                    json,
+                                    Long::class.java
+                            )
+                            handler.onDelete(id)
+                        }
+                    }catch (e:java.io.InterruptedIOException){
+                        break
                     }
                 }
+                reader.close()
             })
             return Shutdownable(dispatcher)
         } else {


### PR DESCRIPTION
・受信データは、event: <<種別>>、data:<<データ内容>>、  以外に :thump というのが時々送られてきているため、元のロジックではその次のデータを読み飛ばしてしまっていました。
これを読み飛ばさないように、また少しだけ確実にデータ取得が出来るように微調整しました。

・ストリーミングをShutdownable.shutdown()メソッドで終了させたとき、reader.readLine() で例外が発生して落ちていたので、キャッチして受信ループを終了させてbufferedReaderをclose()するようにしました。
