### PR TITLE
NullableかNotNullかをAPIドキュメントに沿って変更

### DIFF
--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Application.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Application.kt
@@ -10,5 +10,5 @@ class Application(
         val name: String = "",
 
         @SerializedName("website")
-        val website: String = "") {
+        val website: String? = null) {
 }

--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Attachment.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Attachment.kt
@@ -9,9 +9,9 @@ class Attachment(
         @SerializedName("id") val id: Long = 0L,
         @SerializedName("type") val type: String = Type.Image.value,
         @SerializedName("url") val url: String = "",
-        @SerializedName("remote_url") val remoteUrl: String = "",
+        @SerializedName("remote_url") val remoteUrl: String? = null,
         @SerializedName("preview_url") val previewUrl: String = "",
-        @SerializedName("text_url") val textUrl: String = "") {
+        @SerializedName("text_url") val textUrl: String? = null) {
     enum class Type(val value: String) {
         Image("image"),
         Video("video"),

--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Card.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Card.kt
@@ -16,5 +16,5 @@ class Card(
         val description: String = "",
 
         @SerializedName("image")
-        val image: String = "") {
+        val image: String? = null) {
 }

--- a/mastodon4j/src/test/java/com/sys1yagi/mastodon4j/api/entity/AttachmentTest.kt
+++ b/mastodon4j/src/test/java/com/sys1yagi/mastodon4j/api/entity/AttachmentTest.kt
@@ -3,6 +3,7 @@ package com.sys1yagi.mastodon4j.api.entity
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.testtool.AssetsUtil
 import org.amshove.kluent.shouldEqualTo
+import org.amshove.kluent.shouldNotBe
 import org.junit.Test
 
 class AttachmentTest {
@@ -12,9 +13,9 @@ class AttachmentTest {
         val status: Attachment = Gson().fromJson(json, Attachment::class.java)
         status.id shouldEqualTo 10L
         status.url shouldEqualTo "youtube"
-        status.remoteUrl shouldEqualTo "remote"
+        status.remoteUrl shouldNotBe null
         status.previewUrl shouldEqualTo "preview"
-        status.textUrl shouldEqualTo "text"
+        status.textUrl shouldNotBe null
         status.type shouldEqualTo Attachment.Type.Video.value
     }
 }

--- a/mastodon4j/src/test/java/com/sys1yagi/mastodon4j/api/method/MediaTest.kt
+++ b/mastodon4j/src/test/java/com/sys1yagi/mastodon4j/api/method/MediaTest.kt
@@ -5,6 +5,7 @@ import com.sys1yagi.mastodon4j.extension.emptyRequestBody
 import com.sys1yagi.mastodon4j.testtool.MockClient
 import okhttp3.MultipartBody
 import org.amshove.kluent.shouldEqualTo
+import org.amshove.kluent.shouldNotBe
 import org.junit.Test
 
 class MediaTest {
@@ -16,9 +17,9 @@ class MediaTest {
         attachment.id shouldEqualTo 10
         attachment.type shouldEqualTo "video"
         attachment.url shouldEqualTo "youtube"
-        attachment.remoteUrl shouldEqualTo "remote"
+        attachment.remoteUrl shouldNotBe null
         attachment.previewUrl shouldEqualTo "preview"
-        attachment.textUrl shouldEqualTo "text"
+        attachment.textUrl shouldNotBe  null
     }
 
     @Test(expected = Mastodon4jRequestException::class)

--- a/mastodon4j/src/test/java/com/sys1yagi/mastodon4j/api/method/StatusesTest.kt
+++ b/mastodon4j/src/test/java/com/sys1yagi/mastodon4j/api/method/StatusesTest.kt
@@ -3,6 +3,7 @@ package com.sys1yagi.mastodon4j.api.method
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
 import com.sys1yagi.mastodon4j.testtool.MockClient
 import org.amshove.kluent.shouldEqualTo
+import org.amshove.kluent.shouldNotBe
 import org.junit.Test
 
 import org.junit.Assert.*
@@ -47,7 +48,7 @@ class StatusesTest {
         card.url shouldEqualTo "The url associated with the card"
         card.title shouldEqualTo "The title of the card"
         card.description shouldEqualTo "The card description"
-        card.image shouldEqualTo "The image associated with the card, if any"
+        card.image shouldNotBe null
     }
 
     @Test(expected = Mastodon4jRequestException::class)


### PR DESCRIPTION
[ドキュメント](https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md)に従って、ドキュメントにNullableと書かれているentityのattributeをNullableにしました