### PR TITLE
Add Emojis by Account

### DIFF
--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Account.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Account.kt
@@ -15,5 +15,6 @@ class Account(
         @SerializedName("created_at") val createdAt: String = "",
         @SerializedName("followers_count") val followersCount: Int = 0,
         @SerializedName("following_count") val followingCount: Int = 0,
-        @SerializedName("statuses_count") val statusesCount: Int = 0) {
+        @SerializedName("statuses_count") val statusesCount: Int = 0,
+        @SerializedName("emojis") val emojis: List<Emoji> = emptyList()){
 }

--- a/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Emoji.kt
+++ b/mastodon4j/src/main/java/com/sys1yagi/mastodon4j/api/entity/Emoji.kt
@@ -13,5 +13,8 @@ class Emoji(
         val staticUrl: String = "",
 
         @SerializedName("url")
-        val url: String = "") {
+        val url: String = "",
+
+        @SerializedName("visible_in_picker")
+        val visibleInPicker: Boolean = true) {
 }

--- a/mastodon4j/src/test/assets/account.json
+++ b/mastodon4j/src/test/assets/account.json
@@ -13,6 +13,14 @@
   "avatar": "test",
   "avatar_static": "test",
   "header": "test",
-  "header_static": "test"
+  "header_static": "test",
+  "emojis": [
+    {
+      "shortcode": "test",
+      "url": "https://test.jp/images/custom_emojis/images/000/001/576/original/test.png",
+      "static_url": "https://test.jp/images/custom_emojis/images/000/001/576/static/test.png",
+      "visible_in_picker": true
+    }
+  ]
 }
 


### PR DESCRIPTION
entity.AccountにEmojisが無く、display_nameにカスタム絵文字が存在すると画像が参照出来ないので追加しました。entity.Emojiのvisible_in_pickerは実際にAPIを叩いたときに帰ってくるJSONのデータに対して不足していたので追加しました。